### PR TITLE
msm8976-common: Use correct ANT+ wireless device

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -59,7 +59,7 @@ BOARD_CUSTOM_BOOTIMG_MK := hardware/samsung/mkbootimg.mk
 TARGET_KERNEL_SOURCE := kernel/samsung/msm8976
 
 # ANT+
-BOARD_ANT_WIRELESS_DEVICE := "vfs-prerelease"
+BOARD_ANT_WIRELESS_DEVICE := "qualcomm-uart"
 
 # Audio
 AUDIO_FEATURE_ENABLED_AAC_ADTS_OFFLOAD := true


### PR DESCRIPTION
* Stock ROM uses qualcomm-uart instead of vfs-prerelease.

Change-Id: I835763de40d8dcf24d859f29357598fc87ecf9d2