### PR TITLE
msm8976-common: Disable wifi firmware and packet logging

### DIFF
--- a/wifi/WCNSS_qcom_cfg.ini
+++ b/wifi/WCNSS_qcom_cfg.ini
@@ -454,7 +454,7 @@ gEnablePowerSaveOffload=1
 gEnablefwprint=0
 
 #Enable firmware log
-gEnablefwlog=1
+gEnablefwlog=0
 # Additional firmware log levels
 #gFwDebugLogLevel=4
 #gFwDebugModuleLoglevel=1,0,2,0,4,0,5,0,6,0,7,4,8,0,9,0,11,0,13,0,17,0,18,0,19,0,27,0,29,0,31,0,35,0,36,0,38,0
@@ -527,6 +527,9 @@ ssdp = 0
 
 #Enable Memory Deep Sleep
 gEnableMemDeepSleep=1
+
+#Disable packet log feature
+gEnablePacketLog=0
 
 # Bus bandwidth threshold values in terms of number of packets
 gBusBandwidthHighThreshold=2000


### PR DESCRIPTION
The wifi packet logging option has high overhead and several
security issues related to it.  Also, packet logging has issues
when the device goes into low power mode and can cause connectivity
problems when the screen turns off.  It is best to disable it.

Change-Id: Iac7bdb000c0e22ba9930365b6d8477b4c12a3248